### PR TITLE
Revert to API token auth; drop session auth workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@
 
 ## Branches
 
-- `main` — 9 confirmed-working tools (allowlisted or public routes only)
-- `all-endpoints` — full 46-tool implementation; activate once ReadMeABook's API token allowlist is expanded
+- `main` — stable; API token auth only; full 46-tool set (blocked endpoints return 403 until upstream allowlist is expanded — tracked in kikootwo/ReadMeABook#176)
+- `revert-to-api-key-auth` — PR #1; cleans up session auth workaround
 
 ## Why most endpoints are blocked
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "readmeabook-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for ReadMeABook - audiobook management automation",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/client.test.ts
+++ b/src/__tests__/client.test.ts
@@ -6,22 +6,13 @@ import { ReadMeABookClient } from "../client.js";
 // ---------------------------------------------------------------------------
 
 const BASE = "http://localhost:3000";
-const USERNAME = "testuser";
-const PASSWORD = "testpass";
-const JWT_TOKEN = "test-jwt-token";
+const TOKEN = "test-token";
 
 function makeClient() {
-  return new ReadMeABookClient({ baseUrl: BASE, username: USERNAME, password: PASSWORD });
+  return new ReadMeABookClient({ baseUrl: BASE, apiToken: TOKEN });
 }
 
 const mockFetch = vi.fn();
-
-function loginOk() {
-  mockFetch.mockResolvedValueOnce({
-    ok: true,
-    json: () => Promise.resolve({ success: true, accessToken: JWT_TOKEN, refreshToken: "refresh-token" }),
-  });
-}
 
 function ok(data: unknown) {
   mockFetch.mockResolvedValueOnce({
@@ -55,7 +46,6 @@ function lastCall() {
 
 beforeEach(() => {
   vi.stubGlobal("fetch", mockFetch);
-  loginOk(); // every test gets a login mock — client authenticates on first request
 });
 
 afterEach(() => {
@@ -70,7 +60,7 @@ afterEach(() => {
 describe("ReadMeABookClient", () => {
   describe("constructor", () => {
     it("strips trailing slash from baseUrl", async () => {
-      const c = new ReadMeABookClient({ baseUrl: `${BASE}/`, username: USERNAME, password: PASSWORD });
+      const c = new ReadMeABookClient({ baseUrl: `${BASE}/`, apiToken: TOKEN });
       ok({ status: "ok" });
       await c.getHealth();
       expect(lastCall()[0]).toBe(`${BASE}/api/health`);
@@ -83,7 +73,7 @@ describe("ReadMeABookClient", () => {
       await makeClient().getHealth();
       const [, init] = lastCall();
       expect((init.headers as Record<string, string>)["Authorization"]).toBe(
-        `Bearer ${JWT_TOKEN}`
+        `Bearer ${TOKEN}`
       );
       expect((init.headers as Record<string, string>)["Content-Type"]).toBe(
         "application/json"
@@ -359,7 +349,7 @@ describe("ReadMeABookClient", () => {
       async (action) => {
         ok({});
         await makeClient().swipeBookDate("rec-uuid", action);
-        expect(mockFetch).toHaveBeenCalledTimes(2); // login + swipe
+        expect(mockFetch).toHaveBeenCalledOnce();
       }
     );
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,63 +10,28 @@ import type {
 
 export interface ReadMeABookConfig {
   baseUrl: string;
-  username: string;
-  password: string;
-}
-
-interface LoginResponse {
-  success: boolean;
-  accessToken: string;
-  refreshToken: string;
+  apiToken: string;
 }
 
 export class ReadMeABookClient {
   private readonly baseUrl: string;
-  private readonly username: string;
-  private readonly password: string;
-  private jwtToken: string | null = null;
+  private readonly apiToken: string;
 
   constructor(config: ReadMeABookConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
-    this.username = config.username;
-    this.password = config.password;
+    this.apiToken = config.apiToken;
   }
 
-  private async login(): Promise<void> {
-    const url = `${this.baseUrl}/api/auth/admin/login`;
-    const response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username: this.username, password: this.password }),
-    });
-    if (!response.ok) {
-      throw new Error(`Login failed: HTTP ${response.status}`);
-    }
-    const body = (await response.json()) as LoginResponse;
-    this.jwtToken = body.accessToken;
-  }
-
-  private async request<T>(path: string, options: RequestInit = {}, isRetry = false): Promise<T> {
-    if (!this.jwtToken) {
-      await this.login();
-    }
-
+  private async request<T>(path: string, options: RequestInit = {}): Promise<T> {
     const url = `${this.baseUrl}/api${path}`;
     const response = await fetch(url, {
       ...options,
       headers: {
         "Content-Type": "application/json",
-        Authorization: `Bearer ${this.jwtToken}`,
+        Authorization: `Bearer ${this.apiToken}`,
         ...options.headers,
       },
     });
-
-    // On 401, re-login once and retry
-    if (response.status === 401 && !isRetry) {
-      this.jwtToken = null;
-      await this.login();
-      return this.request<T>(path, options, true);
-    }
 
     if (!response.ok) {
       let errorMessage = `HTTP ${response.status}: ${response.statusText}`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,16 +14,15 @@ import { toolDefinitions, toolHandlers } from "./tools.js";
 // ---------------------------------------------------------------------------
 
 const BASE_URL = process.env.READMEABOOK_URL;
-const USERNAME = process.env.READMEABOOK_USERNAME;
-const PASSWORD = process.env.READMEABOOK_PASSWORD;
+const API_TOKEN = process.env.READMEABOOK_TOKEN;
 
 if (!BASE_URL) {
   console.error("Error: READMEABOOK_URL environment variable is required.");
   process.exit(1);
 }
 
-if (!USERNAME || !PASSWORD) {
-  console.error("Error: READMEABOOK_USERNAME and READMEABOOK_PASSWORD environment variables are required.");
+if (!API_TOKEN) {
+  console.error("Error: READMEABOOK_TOKEN environment variable is required.");
   process.exit(1);
 }
 
@@ -40,8 +39,7 @@ const { version } = require("../package.json") as { version: string };
 
 const client = new ReadMeABookClient({
   baseUrl: BASE_URL,
-  username: USERNAME,
-  password: PASSWORD,
+  apiToken: API_TOKEN,
 });
 
 const server = new Server(


### PR DESCRIPTION
## Summary

- Reverts `ReadMeABookClient` to API-token-only auth — removes username/password session auth, JWT login, and token refresh logic
- `READMEABOOK_TOKEN` is now the sole required credential (`READMEABOOK_USERNAME` / `READMEABOOK_PASSWORD` removed)
- Config type simplified: `apiToken` is now required (not optional)
- Bumps version to 0.2.0

## Why

The session auth workaround was added to bypass the upstream API token allowlist, which blocks all but 5 endpoints. Using admin credentials in a headless MCP server is not a clean solution. The proper fix is expanding the allowlist upstream — tracked in kikootwo/ReadMeABook#176.

This PR keeps `main` clean until that lands.

## Test plan

- [x] All 129 unit tests pass
- [x] Build succeeds