### PR TITLE
chore: add tracked git hooks via .githooks/

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,7 +1,12 @@
 #!/bin/sh
-# Run TypeScript build after branch checkout
-# $3 is 1 for branch checkout, 0 for file checkout
+# Run TypeScript build after branch checkout.
+# $3 is 1 for branch checkout, 0 for file checkout — skip file restores.
+# Build may fail mid-feature if the branch has type errors; that's expected.
 if [ "$3" = "1" ]; then
   echo "Running build after checkout..."
   npm run build
+  if [ $? -ne 0 ]; then
+    echo "Build failed — dist/ may be stale."
+    exit 1
+  fi
 fi

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Run TypeScript build after branch checkout
+# $3 is 1 for branch checkout, 0 for file checkout
+if [ "$3" = "1" ]; then
+  echo "Running build after checkout..."
+  npm run build
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Run TypeScript build before commit
+echo "Running build before commit..."
+npm run build
+if [ $? -ne 0 ]; then
+  echo "Build failed. Commit aborted."
+  exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Run unit tests before push
+echo "Running tests before push..."
+npm test
+if [ $? -ne 0 ]; then
+  echo "Tests failed. Push aborted."
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "prepare": "npm run build && git config core.hooksPath .githooks",
+    "prepare": "npm run build && (git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .githooks || true)",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
-    "prepare": "npm run build",
+    "prepare": "npm run build && git config core.hooksPath .githooks",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage"


### PR DESCRIPTION
## Summary
- Moves git hooks into `.githooks/` so they are committed to the repo and shared across clones
- Adds `post-checkout` hook that runs `npm run build` on branch switches
- Migrates existing `pre-commit` and `pre-push` hooks into `.githooks/` as well
- Wires up via `prepare` script so `npm install` automatically configures git to use `.githooks/`

## Test plan
- [ ] `npm install` sets `core.hooksPath` to `.githooks`
- [ ] Switching branches triggers a build
- [ ] `pre-commit` and `pre-push` still fire as before

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)