### PR TITLE
Add Dependabot npm version update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+      timezone: "America/Toronto"
+    commit-message:
+      prefix: "chore"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to enable weekly automated PRs for npm dependency version updates
- Scheduled for Mondays

Closes #9