### PR TITLE
fix: run npm install before build in post-checkout hook

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -3,10 +3,10 @@
 # $3 is 1 for branch checkout, 0 for file checkout — skip file restores.
 # Build may fail mid-feature if the branch has type errors; that's expected.
 if [ "$3" = "1" ]; then
-  echo "Running npm install after checkout..."
-  npm install
+  echo "Running npm ci after checkout..."
+  npm ci
   if [ $? -ne 0 ]; then
-    echo "npm install failed."
+    echo "npm ci failed — node_modules may be out of date."
     exit 1
   fi
   echo "Running build after checkout..."

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Run npm install then TypeScript build after branch checkout.
+# Run npm ci then TypeScript build after branch checkout.
 # $3 is 1 for branch checkout, 0 for file checkout — skip file restores.
 # Build may fail mid-feature if the branch has type errors; that's expected.
 if [ "$3" = "1" ]; then

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,8 +1,14 @@
 #!/bin/sh
-# Run TypeScript build after branch checkout.
+# Run npm install then TypeScript build after branch checkout.
 # $3 is 1 for branch checkout, 0 for file checkout — skip file restores.
 # Build may fail mid-feature if the branch has type errors; that's expected.
 if [ "$3" = "1" ]; then
+  echo "Running npm install after checkout..."
+  npm install
+  if [ $? -ne 0 ]; then
+    echo "npm install failed."
+    exit 1
+  fi
   echo "Running build after checkout..."
   npm run build
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary
- Adds `npm install` before `npm run build` in `.githooks/post-checkout`
- Prevents stale `node_modules` when switching between branches with different dependencies (e.g. Dependabot bump PRs)

Closes #12