### PR TITLE
ci: add GitHub Actions workflow for build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Read Node version
-        id: nvmrc
-        run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ steps.nvmrc.outputs.version }}
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,91 @@ jobs:
           name: coverage
           path: coverage/
           retention-days: 30
+
+  coverage-regression:
+    name: Coverage regression check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      # --- baseline: main branch ---
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main-branch
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: main-branch/.nvmrc
+          cache: npm
+
+      - name: Install dependencies (main)
+        run: npm ci
+        working-directory: main-branch
+
+      - name: Run coverage (main)
+        run: npm run test:coverage
+        working-directory: main-branch
+
+      - name: Extract baseline coverage
+        id: baseline
+        run: |
+          PCT=$(node -e "
+            import { readFileSync } from 'fs';
+            const s = JSON.parse(readFileSync('./main-branch/coverage/coverage-summary.json', 'utf8'));
+            console.log(s.total.lines.pct);
+          " --input-type=module)
+          echo "pct=$PCT" >> "$GITHUB_OUTPUT"
+          echo "Baseline (main) line coverage: $PCT%"
+
+      # --- PR branch ---
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr-branch
+
+      - name: Install dependencies (PR)
+        run: npm ci
+        working-directory: pr-branch
+
+      - name: Run coverage (PR)
+        run: npm run test:coverage
+        working-directory: pr-branch
+
+      - name: Extract PR coverage
+        id: pr
+        run: |
+          PCT=$(node -e "
+            import { readFileSync } from 'fs';
+            const s = JSON.parse(readFileSync('./pr-branch/coverage/coverage-summary.json', 'utf8'));
+            console.log(s.total.lines.pct);
+          " --input-type=module)
+          echo "pct=$PCT" >> "$GITHUB_OUTPUT"
+          echo "PR line coverage: $PCT%"
+
+      # --- compare ---
+      - name: Compare coverage
+        run: |
+          BASELINE=${{ steps.baseline.outputs.pct }}
+          PR=${{ steps.pr.outputs.pct }}
+          echo "Baseline (main): ${BASELINE}%"
+          echo "This PR:         ${PR}%"
+          node -e "
+            const base = parseFloat('$BASELINE');
+            const pr   = parseFloat('$PR');
+            if (pr < base) {
+              console.error('');
+              console.error('Coverage regression detected!');
+              console.error('  main:     ' + base + '%');
+              console.error('  this PR:  ' + pr   + '%');
+              console.error('  delta:    ' + (pr - base).toFixed(2) + '%');
+              console.error('');
+              console.error('Please add tests to maintain or improve coverage before merging.');
+              process.exit(1);
+            }
+            const delta = pr - base;
+            console.log('Coverage OK: ' + pr + '% (main: ' + base + '%, delta: +' + delta.toFixed(2) + '%)');
+          "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Build & Test
@@ -45,6 +48,7 @@ jobs:
     name: Coverage regression check
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    needs: [ci]
 
     steps:
       # --- baseline: main branch ---
@@ -54,11 +58,12 @@ jobs:
           ref: main
           path: main-branch
 
-      - name: Set up Node
+      - name: Set up Node (main)
         uses: actions/setup-node@v4
         with:
           node-version-file: main-branch/.nvmrc
           cache: npm
+          cache-dependency-path: main-branch/package-lock.json
 
       - name: Install dependencies (main)
         run: npm ci
@@ -71,13 +76,18 @@ jobs:
       - name: Extract baseline coverage
         id: baseline
         run: |
-          PCT=$(node -e "
+          SUMMARY=$(node -e "
             import { readFileSync } from 'fs';
             const s = JSON.parse(readFileSync('./main-branch/coverage/coverage-summary.json', 'utf8'));
-            console.log(s.total.lines.pct);
+            console.log(JSON.stringify({
+              statements: s.total.statements.pct,
+              branches:   s.total.branches.pct,
+              functions:  s.total.functions.pct,
+              lines:      s.total.lines.pct,
+            }));
           " --input-type=module)
-          echo "pct=$PCT" >> "$GITHUB_OUTPUT"
-          echo "Baseline (main) line coverage: $PCT%"
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+          echo "Baseline (main) coverage: $SUMMARY"
 
       # --- PR branch ---
       - name: Checkout PR branch
@@ -85,6 +95,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr-branch
+
+      - name: Set up Node (PR)
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: pr-branch/.nvmrc
+          cache: npm
+          cache-dependency-path: pr-branch/package-lock.json
 
       - name: Install dependencies (PR)
         run: npm ci
@@ -97,34 +114,45 @@ jobs:
       - name: Extract PR coverage
         id: pr
         run: |
-          PCT=$(node -e "
+          SUMMARY=$(node -e "
             import { readFileSync } from 'fs';
             const s = JSON.parse(readFileSync('./pr-branch/coverage/coverage-summary.json', 'utf8'));
-            console.log(s.total.lines.pct);
+            console.log(JSON.stringify({
+              statements: s.total.statements.pct,
+              branches:   s.total.branches.pct,
+              functions:  s.total.functions.pct,
+              lines:      s.total.lines.pct,
+            }));
           " --input-type=module)
-          echo "pct=$PCT" >> "$GITHUB_OUTPUT"
-          echo "PR line coverage: $PCT%"
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+          echo "PR coverage: $SUMMARY"
 
       # --- compare ---
       - name: Compare coverage
+        env:
+          BASELINE: ${{ steps.baseline.outputs.summary }}
+          PR_COVERAGE: ${{ steps.pr.outputs.summary }}
         run: |
-          BASELINE=${{ steps.baseline.outputs.pct }}
-          PR=${{ steps.pr.outputs.pct }}
-          echo "Baseline (main): ${BASELINE}%"
-          echo "This PR:         ${PR}%"
           node -e "
-            const base = parseFloat('$BASELINE');
-            const pr   = parseFloat('$PR');
-            if (pr < base) {
+            const base = JSON.parse(process.env.BASELINE);
+            const pr   = JSON.parse(process.env.PR_COVERAGE);
+            const metrics = ['statements', 'branches', 'functions', 'lines'];
+            const regressions = [];
+            for (const m of metrics) {
+              const delta = pr[m] - base[m];
+              const line = m.padEnd(11) + ' main: ' + base[m].toFixed(2) + '%  PR: ' + pr[m].toFixed(2) + '%  delta: ' + (delta >= 0 ? '+' : '') + delta.toFixed(2) + '%';
+              if (pr[m] < base[m]) {
+                regressions.push(line);
+                console.error('REGRESSION  ' + line);
+              } else {
+                console.log('OK          ' + line);
+              }
+            }
+            if (regressions.length > 0) {
               console.error('');
-              console.error('Coverage regression detected!');
-              console.error('  main:     ' + base + '%');
-              console.error('  this PR:  ' + pr   + '%');
-              console.error('  delta:    ' + (pr - base).toFixed(2) + '%');
-              console.error('');
+              console.error('Coverage regression detected on ' + regressions.length + ' metric(s).');
               console.error('Please add tests to maintain or improve coverage before merging.');
               process.exit(1);
             }
-            const delta = pr - base;
-            console.log('Coverage OK: ' + pr + '% (main: ' + base + '%, delta: +' + delta.toFixed(2) + '%)');
-          "
+            console.log('All coverage metrics maintained or improved.');
+          " --input-type=module

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read Node version
+        id: nvmrc
+        run: echo "version=$(cat .nvmrc)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.nvmrc.outputs.version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+      - name: Coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 30

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         branches: 90,
         statements: 90,
       },
-      reporter: ["text", "lcov"],
+      reporter: ["text", "lcov", "json-summary"],
     },
   },
 });


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` triggered on push and pull_request to `main`
- Node version is read from `.nvmrc` so it stays in sync without manual updates
- Steps: `npm ci` → `npm run build` → `npm test` → `npm run test:coverage`
- Coverage artifact uploaded with 30-day retention; run fails if 90% thresholds aren't met
- Adds a `coverage-regression` job that runs on PRs: compares PR coverage against `main` baseline and fails if any of statements/branches/functions/lines regresses
- Each branch (main baseline + PR head) is set up with its own `.nvmrc` Node version so coverage is measured under the version that branch declares
- Adds `json-summary` reporter to `vitest.config.ts` so the coverage-regression job can parse `coverage-summary.json`
- Workflow declares `permissions: contents: read`; `coverage-regression` depends on `ci` to avoid burning a runner when the build is already broken

## Test plan

- [ ] Confirm the Actions run appears on this PR after push
- [ ] Confirm all four steps (install, build, test, coverage) pass green
- [ ] Confirm the `coverage` artifact is visible in the run summary
- [ ] Confirm the `coverage-regression` job runs only on PR events (not on push to main) and reports per-metric deltas
- [ ] Merge-block a future PR where a test fails to verify the check gates correctly

Closes #20
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)