### PR TITLE
chore: add *.tsbuildinfo to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 dist/
 coverage/
+*.tsbuildinfo
 *.env
 .env
 .DS_Store


### PR DESCRIPTION
## Summary
- Adds `*.tsbuildinfo` pattern to `.gitignore` to exclude TypeScript incremental build artefacts
- `coverage/` and `dist/` were already correctly ignored; this rounds out the generated-output ignores

## Test plan
- [ ] Verify `.gitignore` diff looks correct
- [ ] Confirm no generated files are accidentally tracked after this change

Closes #22